### PR TITLE
feat: 채팅 프로필 동시간내 보낸 메세지 중 첫 메세지에만 보이게 수정 및 메세지 정렬 수정

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -28,7 +28,12 @@ export const fetchChatLists = async (): Promise<ChatList[]> => {
  */
 export const fetchChatMessages = async (roomId: number, page: number): Promise<ChatMessage[]> => {
   const response = await client.get(`/api/v1/chats/${roomId}/messages?page=${page}`);
-  return response.data.results.sort(
-    (a: ChatMessage, b: ChatMessage) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-  );
+  return response.data.results.sort((a: ChatMessage, b: ChatMessage) => {
+    const timeA = new Date(a.timestamp).getTime();
+    const timeB = new Date(b.timestamp).getTime();
+    if (timeA === timeB) {
+      return a.id - b.id;
+    }
+    return timeA - timeB;
+  });
 };

--- a/src/components/Common/ChatMessageModal.tsx
+++ b/src/components/Common/ChatMessageModal.tsx
@@ -38,6 +38,7 @@ const ChatMessageModal = () => {
       try {
         const fetchedMessages = await fetchChatMessages(activeRoomId, 1);
         setChatMessages(fetchedMessages);
+        console.log(fetchedMessages);
         updateChatRoomPage(activeRoomId, 1);
         setHasMoreMessages(fetchedMessages.length === 20);
         // 초기 로드 후 스크롤을 맨 아래로

--- a/src/components/Common/ChatRenderMessages.tsx
+++ b/src/components/Common/ChatRenderMessages.tsx
@@ -9,6 +9,8 @@ const ChatRenderMessages = ({ chatMessages }: { chatMessages: ChatMessage[] }) =
   const otherUserProfileImage = useChatStore((state) => state.otherUserProfileImage);
 
   let lastMessageDate: string | null = null;
+  let lastSender: string | null = null;
+  let lastMessageTime: string | null = null;
 
   return chatMessages.map((message: ChatMessage, index: number) => {
     const messageDate = formatDate(message.timestamp);
@@ -19,8 +21,12 @@ const ChatRenderMessages = ({ chatMessages }: { chatMessages: ChatMessage[] }) =
       !nextMessage ||
       nextMessage.sender_nickname !== message.sender_nickname ||
       !isSameMinute(messageTime, formatTime(nextMessage.timestamp));
+    const isFirstMessageFromSender =
+      message.sender_nickname !== lastSender || !isSameMinute(messageTime, lastMessageTime);
 
     lastMessageDate = messageDate;
+    lastSender = message.sender_nickname;
+    lastMessageTime = messageTime;
 
     return (
       <React.Fragment key={message.id}>
@@ -42,7 +48,9 @@ const ChatRenderMessages = ({ chatMessages }: { chatMessages: ChatMessage[] }) =
           ) : (
             <div className='flex'>
               <div className='mx-3 min-h-[49px] min-w-[49px]'>
-                <ProfileImage className='h-[49px] w-[49px] rounded-full object-cover' src={otherUserProfileImage} />
+                {isFirstMessageFromSender && (
+                  <ProfileImage className='h-[49px] w-[49px] rounded-full object-cover' src={otherUserProfileImage} />
+                )}
               </div>
               <p className='max-w-[240px] rounded-chat-other bg-white px-4 py-3 text-justify leading-snug'>
                 {message.message}


### PR DESCRIPTION
**변경 내용 요약**

- 채팅 메세지마다 보이던 상대방 프로필을 첫 메세지에만 보이도록 수정했습니다.
- 메세지 정렬 중 밀리초 단위의 차이에서 버그가 있어, timestamp가 같을 경우 (밀리초까지 동일), id를 기준으로 추가 정렬하도록 수정했습니다. 

**변경 유형**

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

**스크린샷/GIF (Optional)**

![스크린샷 2024-12-27 오후 4 53 06](https://github.com/user-attachments/assets/ebc2265a-49a0-4d4d-ab5b-09770cd974ba)

